### PR TITLE
Adding -pg flag in LDFLAGS for generating gmon.out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,16 @@ all: $(EXEC)
 
 CC ?= gcc
 CFLAGS = \
-	-std=c99 -Wall -O0 -pg -g
+	-std=c99 -Wall -O0 -g
 LDFLAGS = \
 	-lm
+	
+ifeq ($(PROFILE),1)
+PROF_FLAGS = -pg
+
+CFLAGS += $(PROF_FLAGS)
+LDFLAGS += $(PROF_FLAGS) 
+endif
 
 OBJS := \
 	objects.o \


### PR DESCRIPTION
-pg

Generate extra code to write profile information suitable for the analysis program gprof. You must use this option when compiling the source files you want data about, and you must also use it when linking.
